### PR TITLE
Fix for locale_str issue reported in issue #43

### DIFF
--- a/gateone/gateone.py
+++ b/gateone/gateone.py
@@ -1473,7 +1473,7 @@ def main():
         default=default_locale,
         help=_("The locale (e.g. pt_PT) Gate One should use for translations."
              "  If not provided, will default to $LANG (which is '%s' in your "
-             "current shell).") % os.environ['LANG'].split('.')[0],
+             "current shell), or POSIX if not set.") % os.environ.get('LANG', 'not set').split('.')[0],
         type=str
     )
     # Before we do anythong else, load plugins and assign their hooks.  This

--- a/gateone/utils.py
+++ b/gateone/utils.py
@@ -127,6 +127,7 @@ def get_translation():
     gateone_dir = os.path.dirname(os.path.abspath(__file__))
     server_conf = os.path.join(gateone_dir, 'server.conf')
     try:
+	locale_str = os.environ.get('LANG', 'POSIX').split('.')[0]
         with open(server_conf) as f:
             for line in f:
                 if line.startswith('locale'):
@@ -135,7 +136,8 @@ def get_translation():
                     break
     except IOError: # server.conf doesn't exist (yet).
         # Fall back to os.environ['LANG']
-        locale_str = os.environ['LANG'].split('.')[0]
+	# Already set above
+	pass
     user_locale = locale.get(locale_str)
     return user_locale.translate
 


### PR DESCRIPTION
Fix crash if 'locale' isn't in config, and '$LANG' isn't set.
Set locale_str ahead of time, so no matter the path the code takes, it is set.
I also referenced it in issue #36.
