### PR TITLE
Fix previous commit to use en_US as default locale

### DIFF
--- a/gateone/gateone.py
+++ b/gateone/gateone.py
@@ -1473,7 +1473,7 @@ def main():
         default=default_locale,
         help=_("The locale (e.g. pt_PT) Gate One should use for translations."
              "  If not provided, will default to $LANG (which is '%s' in your "
-             "current shell), or POSIX if not set.") % os.environ.get('LANG', 'not set').split('.')[0],
+             "current shell), or en_US if not set.") % os.environ.get('LANG', 'not set').split('.')[0],
         type=str
     )
     # Before we do anythong else, load plugins and assign their hooks.  This

--- a/gateone/utils.py
+++ b/gateone/utils.py
@@ -127,7 +127,7 @@ def get_translation():
     gateone_dir = os.path.dirname(os.path.abspath(__file__))
     server_conf = os.path.join(gateone_dir, 'server.conf')
     try:
-	locale_str = os.environ.get('LANG', 'POSIX').split('.')[0]
+	locale_str = os.environ.get('LANG', 'en_US').split('.')[0]
         with open(server_conf) as f:
             for line in f:
                 if line.startswith('locale'):


### PR DESCRIPTION
Per comment: https://github.com/liftoff/GateOne/issues/36#issuecomment-2521379
The default seems to be en_US. I originally changed the diff on the discussion to use en_US, but forgot to change the original code before I made the last commit.
