### PR TITLE
utils.py: fix bug about get list of enable plugins

### DIFF
--- a/gateone/utils.py
+++ b/gateone/utils.py
@@ -717,7 +717,7 @@ def get_plugins(plugin_dir):
     out_dict = {'js': [], 'css': [], 'py': []}
     plugins_conf_path = plugin_dir + '.conf'
     try:
-        enabled_plugins = open(plugins_conf_path).readlines()
+        enabled_plugins = open(plugins_conf_path).read().split()
         if not enabled_plugins or "*" in enabled_plugins:
             logging.debug(_('Loading all plugins'))
             enabled_plugins = None


### PR DESCRIPTION
The old way to get the list kept break-lines.
