### PR TITLE
Systemd service

### DIFF
--- a/scripts/init/gateone.service
+++ b/scripts/init/gateone.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Web-based terminal
+
+[Service]
+Type=simple
+PIDFile=/tmp/gateone.pid
+WorkingDirectory=/opt/gateone
+ExecStart=/opt/gateone/gateone.py
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Added a service file to control GateOne using `systemctl {enable | disable | stop | start | restart} gateone` on distros where systemd is used.
