### PR TITLE
 UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1484: ordinal not in range(128)

### DIFF
--- a/gateone/gateone.py
+++ b/gateone/gateone.py
@@ -2332,7 +2332,7 @@ class ErrorHandler(tornado.web.RequestHandler):
             filename = os.path.join(
                 self.settings['static_url'], '%d.html' % status_code)
             if os.path.exists(filename):
-                f = io.open(filename, 'r')
+                f = io.open(filename, 'rb')
                 data = f.read()
                 f.close()
                 return data


### PR DESCRIPTION
Handling http error 404 raises exception 
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1484: ordinal not in range(128)

Related issue https://github.com/liftoff/GateOne/issues/249
