### PR TITLE
call install-rpm.sh when building RPMs

### DIFF
--- a/install-rpm.sh
+++ b/install-rpm.sh
@@ -1,0 +1,2 @@
+python setup.py install --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+sed -i -e 's/^.*$/"&"/g' INSTALLED_FILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ requires = python >= 2.6
 provides = gateone
 group = Applications/System
 doc_files = gateone/docs/html
+install_script = install-rpm.sh
 
 [install]
 # This is necessary to prevent *.pyo files from messing up bdist_rpm:


### PR DESCRIPTION
call install-rpm.sh when building RPMs to wrap lines in INSTALLED_FILES with " catching files that have whitespaces within filenames.
