### PR TITLE
added shell_command_is_shell to save 1 process by terminal

### DIFF
--- a/gateone/applications/terminal/app_terminal.py
+++ b/gateone/applications/terminal/app_terminal.py
@@ -876,6 +876,7 @@ class TerminalApplication(GOApplication):
         policies = applicable_policies(
             'terminal', self.current_user, self.ws.prefs)
         shell_command = policies.get('shell_command', None)
+	shell_command_is_shell = policies.get('shell_command_is_shell', True)
         user_dir = self.settings['user_dir']
         try:
             user = self.current_user['upn']
@@ -924,6 +925,7 @@ class TerminalApplication(GOApplication):
             additional_metadata=additional_log_metadata,
             encoding=encoding
         )
+	m.shell_command_is_shell = shell_command_is_shell
         if shell_command:
             m.shell_command = shell_command
         if self.plugin_new_multiplex_hooks:

--- a/termio/termio.py
+++ b/termio/termio.py
@@ -1185,6 +1185,7 @@ class MultiplexPOSIXIOLoop(BaseMultiplex):
         self.terminating = False
         self.sent_sigint = False
         self.shell_command = ['/bin/sh', '-c']
+	self_shell_command_is_shell = True
         self.env = {}
         self.io_loop = ioloop.IOLoop.current() # Monitors child for activity
         #self.io_loop.set_blocking_signal_threshold(2, self._blocked_io_handler)
@@ -1336,7 +1337,10 @@ class MultiplexPOSIXIOLoop(BaseMultiplex):
             if not isinstance(self.shell_command, list):
                 import shlex
                 self.shell_command = shlex.split(self.shell_command)
-            cmd = self.shell_command + [self.cmd + '; sleep .1']
+            if self.shell_command_is_shell:
+                cmd = self.shell_command + [self.cmd + '; sleep .1']
+            else:
+	        cmd = self.shell_command + [self.cmd ]
             # This loop prevents UnicodeEncodeError exceptions:
             for k, v in env.items():
                 if isinstance(v, unicode):


### PR DESCRIPTION
Hi Daniel.

I Would like to contribute to your great project.

As you know we are working with gateone in embedded mode in the ITSAT project and we need to exec a external command (  in  our case a php  console script  /usr/bin/php5 -f <our_console_scrip> )

if we put this config

```
       "commands": {

            "ITSAT-SHELL": {
                "command": " /usr/bin/php5 -f /opt/itsat/usr/bin/rcpsh",
                "description": "Connect to hosts via ITSAT SHELL."
            }
        },
```

On each opened terminal we had this process tree

<pre>
gateone,2175 /usr/local/bin/gateone --settings_dir=/opt/itsat/etc/gateone
  +-sh,3465 -c /usr/bin/php5 -f /opt/itsat/usr/bin/rcpsh; sleep .1
      +-/usr/bin/php5 -f /opt/itsat/usr/bin/rcpsh ,3466
</pre>


Now I can Configure GateOne Terminal 

```
       "commands": {
            "ITSAT-SHELL": {
                "command": "/opt/itsat/usr/bin/rcpsh",
                "description": "Connect to hosts via ITSAT SHELL."
            }
        },
        "shell_command": "/usr/bin/php5 -f",
        "shell_command_is_shell": false,
```

And the process tree is 

<pre>
 python,4302 /usr/local/bin/gateone --settings_dir=/opt/itsat/etc/gateone
  +-/usr/bin/php5 -f /opt/itsat/usr/bin/rcpsh ,4424
</pre>


This commit saves 1 process ( a shell ) by opened terminal when you want to exec another binary command that is not a shell.( php5 in my case) and is necesary to avoid the sleep .1 attached to the command. And also enables faster executions.
