### PR TITLE
changed path to gateone/docs/html. 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ vendor = Liftoff Software
 requires = python >= 2.6
 provides = gateone
 group = Applications/System
-doc_files = gateone/docs/html
+doc_files = gateone/docs/build/html
 install_script = install-rpm.sh
 
 [install]


### PR DESCRIPTION
Without this bdist fails to build RPM.
