### PR TITLE
Fix for problem with `valid_hostname` method in Python 3

### DIFF
--- a/gateone/core/utils.py
+++ b/gateone/core/utils.py
@@ -1351,7 +1351,7 @@ def valid_hostname(hostname, allow_underscore=False):
     allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
     if allow_underscore:
         allowed = re.compile("(?!-)[_A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
-    hostnameString = str( hostname, ecoding='idna' )
+    hostnameString = str( hostname, encoding='idna' )
     return all(allowed.match(x) for x in hostnameString.split('.'))
 
 def recursive_chown(path, uid, gid):


### PR DESCRIPTION
It appears that splitting a string that has 'idna' encoding causes a crash in Python 3. I have added 1 line to create a string from the encoded hostname and then split that string. This fixes the crash on my system with Tornado 3.2.1 and Python 3.2.3.
