### PR TITLE
Changes to terminal.py to work on Python 3

### DIFF
--- a/terminal/terminal.py
+++ b/terminal/terminal.py
@@ -170,13 +170,17 @@ except ImportError:  # Python 3 doesn't have imap or izip in itertool
     imap = map
     izip = zip
 try:
-    dummy = xrange
+    xrange = xrange
 except NameError:  # Python 3 doesn't have xrange()
     xrange = range
 try:
-    dummy = unichr
+    unichr = unichr
 except NameError:  # Python 3 doesn't have unichr()
     unichr = chr
+try:
+    basestring = basestring
+except NameError:  # Python 3 doesn't have basestring
+    basestring = (str, bytes)
 
 # Inernationalization support
 _ = str # So pyflakes doesn't complain

--- a/terminal/terminal.py
+++ b/terminal/terminal.py
@@ -166,12 +166,16 @@ except ImportError: # Python <2.7 didn't have OrderedDict in collections
         sys.exit(1)
 try:
     from itertools import imap, izip
-except ImportError: # Python 3 doesn't have imap or izip in itertool
+except ImportError:  # Python 3 doesn't have imap or izip in itertool
     imap = map
     izip = zip
-if 'xrange' not in dir(__builtins__):   # Python 3 doesn't have xrange()
+try:
+    dummy = xrange
+except NameError:  # Python 3 doesn't have xrange()
     xrange = range
-if 'unichr' not in dir(__builtins__):   # Python 3 doesn't have unichr()
+try:
+    dummy = unichr
+except NameError:  # Python 3 doesn't have unichr()
     unichr = chr
 
 # Inernationalization support

--- a/terminal/terminal.py
+++ b/terminal/terminal.py
@@ -164,7 +164,15 @@ except ImportError: # Python <2.7 didn't have OrderedDict in collections
         logging.error(
             "...or download it from http://pypi.python.org/pypi/ordereddict")
         sys.exit(1)
-from itertools import imap, izip
+try:
+    from itertools import imap, izip
+except ImportError: # Python 3 doesn't have imap or izip in itertool
+    imap = map
+    izip = zip
+if 'xrange' not in dir(__builtins__):   # Python 3 doesn't have xrange()
+    xrange = range
+if 'unichr' not in dir(__builtins__):   # Python 3 doesn't have unichr()
+    unichr = chr
 
 # Inernationalization support
 _ = str # So pyflakes doesn't complain
@@ -2811,7 +2819,7 @@ class Terminal(object):
                         else:
                             logging.warning(_(
                                 "Warning: No ESC sequence handler for %s"
-                                % `self.esc_buffer`
+                                % repr(self.esc_buffer)
                             ))
                             self.esc_buffer = ''
                     continue # We're done here


### PR DESCRIPTION
This is a minimal set of changes, just mapping the use of Python 2-specific idioms into workable Python 3 versions.

The biggest worry is probably the mapping of `unichr()` to `chr()`. This implies that there is Unicode handling, which almost certainly means that something doesn't work. I didn't see a test suite to run it through to verify the behavior, so I'm hoping for the best. 