### PR TITLE
Fix incorrect hostname error on using ipv6 address

### DIFF
--- a/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py
+++ b/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py
@@ -839,8 +839,11 @@ def main():
                         url = None
                         raw_input(invalid_hostname_err)
                 else:
-                    url = None
-                    raw_input(invalid_hostname_err)
+                    if valid_ip(host):
+                        validated = True
+                    else:
+                        url = None
+                        raw_input(invalid_hostname_err)
         validated = False
         if options.auth_only:
             port = options.default_port


### PR DESCRIPTION
Added extra check in case the ipv6 address in host variable comes from parser without square brackets.