### PR TITLE
fixing script execution bug when /bin/sh is symlinked to busybox

### DIFF
--- a/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py
+++ b/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py
@@ -467,8 +467,17 @@ def openssh_connect(
     os.chmod(script_path, 0o700) # 0700 for good security practices
     # Execute then immediately quit so we don't use up any more memory than we
     # need.
-    os.execvpe('/bin/sh', [
-        '-c', script_path, '&&', 'rm', '-f', script_path], env)
+    
+    # setup default execvpe args
+    args = ['-c', script_path, '&&', 'rm', '-f', script_path]
+    
+    # if we detect /bin/sh linked to busybox then make sure we insert the 'sh'
+    # at the beginning of the args list
+    if os.path.realpath('/bin/sh').endswith('busybox'):
+        args.insert(0, 'sh')
+    
+    os.execvpe('/bin/sh', args, env)
+    
     os._exit(0)
 
 def telnet_connect(user, host, port=23, env=None):


### PR DESCRIPTION
this is a fairly simple bug fix and resolves issues when gateone is deployed to micro systems (like RPi's or a NAS for example) that use busybox as the primary shell.

I am simply checking to see if /bin/sh has a real path that ends with busybox, and if so simply force busybox to run the sh applet that will allow -c to be interpreted as a command arg and not an applet.

This may resolve (or at least is related to) issue #249 (see my comment there for some insight into this issue). Issue #501 explains the behaviour that I was experiencing, and is likely resolved with this fix.