### PR TITLE
Basic Auth Breaks On Passwords containing : 

### DIFF
--- a/gateone/auth/sso.py
+++ b/gateone/auth/sso.py
@@ -184,7 +184,7 @@ class KerberosAuthMixin(tornado.web.RequestHandler):
         `self.settings['sso_realm']`.
         """
         auth_decoded = base64.decodestring(auth_header[6:])
-        username, password = auth_decoded.split(':', 2)
+        username, password = auth_decoded.split(':', 1)
         try:
             kerberos.checkPassword(
                 username,


### PR DESCRIPTION
Hello, 

Basic auth breaks when you have passwords containg a `:`, by setting [max split](https://docs.python.org/2/library/stdtypes.html#str.split) to 1 you split on the first `:` only which will be after the username [1].

Hope this helps,

Noel

[1] This is assuming you don't have `:` in user names..