### PR TITLE
fixed a bug in ssh_connect.py when /bin/sh is a symlink 

### DIFF
--- a/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py
+++ b/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py
@@ -473,7 +473,7 @@ def openssh_connect(
     
     # if we detect /bin/sh linked to busybox then make sure we insert the 'sh'
     # at the beginning of the args list
-    if os.path.realpath('/bin/sh').endswith('busybox'):
+    if not os.path.realpath('/bin/sh').endswith('/sh'):
         args.insert(0, 'sh')
     
     os.execvpe('/bin/sh', args, env)

--- a/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py
+++ b/gateone/applications/terminal/plugins/ssh/scripts/ssh_connect.py
@@ -473,7 +473,7 @@ def openssh_connect(
     
     # if we detect /bin/sh linked to busybox then make sure we insert the 'sh'
     # at the beginning of the args list
-    if not os.path.realpath('/bin/sh').endswith('/sh'):
+    if os.path.islink('/bin/sh'):
         args.insert(0, 'sh')
     
     os.execvpe('/bin/sh', args, env)


### PR DESCRIPTION
This pull request is an addition to PR #505.
It checks not only if `/bin/sh` is linked to 'busybox' but if it's a symlink in general. With this fix the PR #505 works on more platforms.