### PR TITLE
Fix for Pipe |, Backslash \, Curly Brackets {} and At Sign @ on Mac OS #389

### DIFF
--- a/gateone/applications/terminal/static/terminal_input.js
+++ b/gateone/applications/terminal/static/terminal_input.js
@@ -956,6 +956,7 @@ GateOne.Base.update(GateOne.Terminal.Input, {
         'KEY_8': {'alt': ESC+"8", 'ctrl': String.fromCharCode(32), 'ctrl-shift': String.fromCharCode(32)},
         'KEY_9': {'alt': ESC+"9", 'ctrl': "9", 'ctrl-shift': "9"},
         'KEY_0': {'alt': ESC+"0", 'ctrl': "0", 'ctrl-shift': "0"},
+        'KEY_G': {'altgr': "@"},
         // NOTE to self: xterm/vt100/vt220, for 'linux' (and possibly others) use [[A, [[B, [[C, [[D, and [[E
         'KEY_F1': {'default': ESC+"OP", 'alt': ESC+"O3P", 'sco': ESC+"[M", 'sco-ctrl': ESC+"[k"},
         'KEY_F2': {'default': ESC+"OQ", 'alt': ESC+"O3Q", 'sco': ESC+"[N", 'sco-ctrl': ESC+"[l"},
@@ -1058,9 +1059,9 @@ GateOne.Base.update(GateOne.Terminal.Input, {
         'KEY_FULL_STOP': {'alt': ESC+".", 'alt-shift': ESC+">"},
         'KEY_SOLIDUS': {'alt': ESC+"/", 'alt-shift': ESC+"?", 'ctrl': String.fromCharCode(31), 'ctrl-shift': String.fromCharCode(31)},
         'KEY_GRAVE_ACCENT':  {'alt': ESC+"`", 'alt-shift': ESC+"~", 'ctrl-shift': String.fromCharCode(30)},
-        'KEY_LEFT_SQUARE_BRACKET':  {'alt': ESC+"[", 'alt-shift': ESC+"{", 'ctrl': ESC},
-        'KEY_REVERSE_SOLIDUS':  {'alt': ESC+"\\", 'alt-shift': ESC+"|", 'ctrl': String.fromCharCode(28)},
-        'KEY_RIGHT_SQUARE_BRACKET':  {'alt': ESC+"]", 'alt-shift': ESC+"}", 'ctrl': String.fromCharCode(29)},
+        'KEY_LEFT_SQUARE_BRACKET':  {'altgr': "[", 'alt-shift': ESC+"{", 'ctrl': ESC},
+        'KEY_REVERSE_SOLIDUS':  {'altgr': "|", 'altgr-shift': "\\"},
+        'KEY_RIGHT_SQUARE_BRACKET':  {'altgr': "]", 'alt-shift': ESC+"}", 'ctrl': String.fromCharCode(29)},
         'KEY_APOSTROPHE': {'alt': ESC+"'", 'alt-shift': ESC+'"'}
     }
 });

--- a/gateone/static/gateone_input.js
+++ b/gateone/static/gateone_input.js
@@ -135,6 +135,8 @@ GateOne.Base.update(GateOne.Input, {
             109: 'KEY_NUM_PAD_HYPHEN-MINUS', // Strange: Firefox has this the regular hyphen key (i.e. not the one on the num pad)
             110: 'KEY_NUM_PAD_FULL_STOP',
             111: 'KEY_NUM_PAD_SOLIDUS',
+            123: 'KEY_LEFT_CURLY_BRACKET',
+            125: 'KEY_RIGHT_CURLY_BRACKET',
             144: 'KEY_NUM_LOCK',
             145: 'KEY_SCROLL_LOCK',
             173: 'KEY_HYPHEN-MINUS', // No idea why Firefox uses this keycode instead of 189


### PR DESCRIPTION
Fix for Pipe |, Backslash \, Curly Brackets {} and At Sign @ on Mac OS #389
https://github.com/liftoff/GateOne/issues/389

Tested on both Mac OS X Yosemite and Linux Ubuntu 15.04 with Swiss-French Keyboard
http://www.apple.com/shop/product/MC184/apple-wireless-keyboard-english?fnode=4c

![osx_swiss_french](https://cloud.githubusercontent.com/assets/467676/9481068/8fc45f9c-4b87-11e5-897e-e27cf3bfd953.png)
![osx_swiss_french-altgr](https://cloud.githubusercontent.com/assets/467676/9481069/8fc5b040-4b87-11e5-8866-98ba74dce7a5.png)
![osx_swiss_french-altgr-shift](https://cloud.githubusercontent.com/assets/467676/9481070/8fc687b8-4b87-11e5-9074-7de1b0943675.png)

http://unixpapa.com/js/testkey.html

AltGr+g = @
keydown  keyCode=225       which=225       charCode=0        
keydown  keyCode=71  (G)   which=71  (G)   charCode=0        
keypress keyCode=64  (@)   which=64  (@)   charCode=64  (@)  

AltGr+7 = |
keydown  keyCode=225       which=225       charCode=0        
keydown  keyCode=55  (7)   which=55  (7)   charCode=0        
keypress keyCode=124 (|)   which=124 (|)   charCode=124 (|)  

AltGr+Shift+7 = \
keydown  keyCode=225       which=225       charCode=0        
keydown  keyCode=16        which=16        charCode=0        
keydown  keyCode=55  (7)   which=55  (7)   charCode=0        
keypress keyCode=92  (\)   which=92  (\)   charCode=92  (\)  

AltGr+5 = [
keydown  keyCode=225       which=225       charCode=0        
keydown  keyCode=53  (5)   which=53  (5)   charCode=0        
keypress keyCode=91  ([)   which=91  ([)   charCode=91  ([)  

AltGr+6 = ]
keydown  keyCode=225       which=225       charCode=0        
keydown  keyCode=54  (6)   which=54  (6)   charCode=0        
keypress keyCode=93  (])   which=93  (])   charCode=93  (])  

AltGr+8 = {
keydown  keyCode=225       which=225       charCode=0        
keydown  keyCode=56  (8)   which=56  (8)   charCode=0        
keypress keyCode=123 ({)   which=123 ({)   charCode=123 ({)  

AltGr+9 = }
keydown  keyCode=225       which=225       charCode=0        
keydown  keyCode=57  (9)   which=57  (9)   charCode=0        
keypress keyCode=125 (})   which=125 (})   charCode=125 (})  
