### PR TITLE
Fixing Docker Container Google Auth Issue

### DIFF
--- a/gateone/auth/authentication.py
+++ b/gateone/auth/authentication.py
@@ -308,7 +308,7 @@ class APIAuthHandler(BaseAuthHandler):
         self.finish()
 
 
-class GoogleAuthHandler(BaseAuthHandler, tornado.auth.GoogleOAuth2Mixin):
+class GoogleAuthHandler(BaseAuthHandler, SSL101PatchMixin, tornado.auth.GoogleOAuth2Mixin):
     """
     Google authentication handler using Tornado's built-in GoogleOAuth2Mixin
     (fairly boilerplate).

--- a/gateone/auth/authentication.py
+++ b/gateone/auth/authentication.py
@@ -94,6 +94,11 @@ import tornado.httpclient
 import tornado.gen
 from tornado.options import options
 
+try:
+    import ssl
+except ImportError:
+    ssl = None
+
 # Localization support
 _ = get_translation()
 
@@ -119,6 +124,18 @@ def additional_attributes(user, settings_dir=None):
         settings_dir = options.settings_dir
     return user
 
+
+class SSL101PatchMixin(object):
+    def get_auth_http_client(self):
+        if (ssl is not None and 
+            hasattr(ssl, 'OPENSSL_VERSION_INFO') and
+            ssl.OPENSSL_VERSION_INFO < (1, 0, 2)):
+
+            ca_cert_path = os.getenv('CA_CERT_PATH', '/etc/ssl/certs/ca-certificates.crt')
+            logging.info('Patching tornado HTTP client ssl CA certs for 1.0.1 compatibility (%s)' % ca_cert_path)
+            tornado.httpclient.AsyncHTTPClient.configure(None, defaults=dict(ca_certs=ca_cert_path))
+        
+        return tornado.httpclient.AsyncHTTPClient();
 
 # Authentication classes
 class BaseAuthHandler(tornado.web.RequestHandler):


### PR DESCRIPTION
This patch addresses #596 

I created the patch as a mixin because this patch is likely required for other auth methods and can be easily applied to those methods with minimal effort going forward. I don't have the capacity or environment to test all the other auth methods so I only patched the google auth. I have finished testing out the patch and can confirm everything is working properly. I added the ability to use a custom `ca-certificates.pem` by simply supplying a `CA_CERT_PATH` environment variable with the `docker run` args, though I doubt anyone would really ever need to do that in the general case.

I'm not much of a python dev so feel free to criticize or cleanup this PR. Promise I won't be offended, haha :)
