### PR TITLE
Update authentication.py

### DIFF
--- a/gateone/auth/authentication.py
+++ b/gateone/auth/authentication.py
@@ -645,9 +645,9 @@ class CASAuthHandler(BaseAuthHandler):
             cas_server += '/'
         service_url = "%sauth" % self.base_url
         next_url = self.get_argument('next', None)
-	next_param = ""
-	if next_url:
-		next_param = "?next=" + quote(next_url)
+        next_param = ""
+        if next_url:
+        	next_param = "?next=" + quote(next_url)
         redirect_url = '%slogin?service=%s%s' % (cas_server, quote(service_url), quote(next_param))
         logging.debug("Redirecting to CAS URL: %s" % redirect_url)
         self.redirect(redirect_url)
@@ -671,15 +671,15 @@ class CASAuthHandler(BaseAuthHandler):
         if cas_version == 1:
             validate_suffix = 'validate'
         next_url = self.get_argument('next', None)
-	next_param = ""
-	if next_url:
-		next_param = "?next=" + quote(next_url)
+        next_param = ""
+        if next_url:
+        	next_param = "?next=" + quote(next_url)
         validate_url = (
             cas_server +
             validate_suffix +
             '?service=' +
             quote(service_url) +
-	    quote(next_param) +
+            quote(next_param) +
             '&ticket=' +
             quote(server_ticket)
         )


### PR DESCRIPTION
Fixing: _**TabError: inconsistent use of tabs and spaces in indentation**_, in `gateone/auth/authentication.py, line 648`

Found when attempting to do "`python3 setup.py install`" on Ubuntu 16.04, with Python 3.5.1.

This error didn't happen in python 2, but did when using it in python 3.