### PR TITLE
declare package data in a way that is compatible with wheel packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ version = '1.2.0'
 requires = ["tornado >=4.0", "html5lib >= 0.999"]
 extra = {}
 data_files = []
+package_data = []
+
 major, minor = sys.version_info[:2] # Python version
 if major == 2 and minor <=5:
     print("Gate One requires Python 2.6+.  You are running %s" % sys.version)
@@ -167,12 +169,9 @@ for dirpath, dirnames, filenames in os.walk('gateone'):
     if '__init__.py' in filenames:
         package = '.'.join(fullsplit(dirpath))
         packages.append(package)
-    elif filenames:
-        data_files.append([
-            dirpath, [os.path.join(dirpath, f)
-            for f in filenames
-            if f not in ignore_list]
-        ])
+    else:
+        package_data.extend([os.path.join(*fullsplit(dirpath)[1:] + [fn]) \
+                             for fn in filenames if fn not in ignore_list])
 
 entry_points = {
     'console_scripts': ['gateone = gateone.core.server:main'],
@@ -322,6 +321,7 @@ setup(
     provides = ['gateone', 'termio', 'terminal', 'onoff'],
     packages = packages,
     data_files = data_files,
+    package_data = { 'gateone': package_data },
     **extra
 )
 


### PR DESCRIPTION
This patch fixes package data not being found when installed from wheels. The "package_data" declaration seems to be the most current compatible way in the confusing distutils/setuptools world.

Example error:

```
[root@node-1 wheelize]$ ./edo/bin/gateone --version
Traceback (most recent call last):
  File "./edo/bin/gateone", line 7, in <module>
    from gateone.core.server import main
  File "/root/wheelize/edo/lib/python2.7/site-packages/gateone/core/server.py", line 398, in <module>
    from gateone.auth.authentication import NullAuthHandler, KerberosAuthHandler
  File "/root/wheelize/edo/lib/python2.7/site-packages/gateone/auth/authentication.py", line 86, in <module>
    from gateone.core.locale import get_translation
  File "/root/wheelize/edo/lib/python2.7/site-packages/gateone/core/locale.py", line 25, in <module>
    a for a in resource_listdir('gateone', 'i18n')
  File "/root/wheelize/edo/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1196, in resource_listdir
    resource_name
  File "/root/wheelize/edo/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1487, in resource_listdir
    return self._listdir(self._fn(self.module_path, resource_name))
  File "/root/wheelize/edo/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1575, in _listdir
    return os.listdir(path)
OSError: [Errno 2] No such file or directory: '/root/wheelize/edo/lib/python2.7/site-packages/gateone/i18n'


[root@node-1 wheelize]$ ./edo/bin/pip list
backports-abc (0.4)
backports.ssl-match-hostname (3.5.0.1)
certifi (2016.8.8)
futures (3.0.5)
gateone (1.2.0)
html5lib (0.999999999)
pip (8.1.2)
setuptools (25.1.6)
singledispatch (3.4.0.3)
six (1.10.0)
tornado (4.4.1)
webencodings (0.5)
wheel (0.29.0)
```
