### PR TITLE
get terminal font size from preferences when loading font

### DIFF
--- a/gateone/applications/terminal/static/terminal.js
+++ b/gateone/applications/terminal/static/terminal.js
@@ -849,7 +849,7 @@ go.Base.update(GateOne.Terminal, {
         logDebug('loadFont(' + font + ", " + size + ")");
         font = font || go.prefs.terminalFont;
         var settings = {'font_family': font};
-        if (size) {settings['font_size'] = size}
+        settings['font_size'] = size || go.prefs.terminalFontSize;
         go.ws.send(JSON.stringify({'terminal:get_font': settings}));
     },
     loadTextColors: function(colors) {


### PR DESCRIPTION
Setting the terminalFontSize in init via `GateOne.init({
    "terminalFontSize": "150%"
});` seems not to have any effect because loadFont() does not use default terminalFontSize when the size parameter is falsy. 
